### PR TITLE
ISSUE 19: Delete SNAPSHOT suffix from app jar full name

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT $JAVA_OPTS -jar build/libs/street-art-1.0-SNAPSHOT.jar
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar build/libs/street-art-1.0.jar


### PR DESCRIPTION
In Procfile file, incorrect app jar name. Extra -SNAPSHOT suffix at the end of the name. 